### PR TITLE
feat: split netCDF4 output for grid and drift types to address #154

### DIFF
--- a/doc/source/api_reference/spatial.rst
+++ b/doc/source/api_reference/spatial.rst
@@ -50,6 +50,10 @@ General Methods
 
 .. autofunction:: pyTMD.spatial.to_netCDF4
 
+.. autofunction:: pyTMD.spatial._drift_netCDF4
+
+.. autofunction:: pyTMD.spatial._grid_netCDF4
+
 .. autofunction:: pyTMD.spatial.to_HDF5
 
 .. autofunction:: pyTMD.spatial.to_geotiff

--- a/doc/source/getting_started/Getting-Started.rst
+++ b/doc/source/getting_started/Getting-Started.rst
@@ -51,7 +51,7 @@ Presently, the following models and their directories parameterized within ``pyT
     * `AODTM-5 <https://arcticdata.io/catalog/view/doi:10.18739/A2901ZG3N>`_: ``<path_to_tide_models>/aodtm5_tmd/``
     * `AOTIM-5 <https://arcticdata.io/catalog/view/doi:10.18739/A2S17SS80>`_: ``<path_to_tide_models>/aotim5_tmd/``
     * `AOTIM-5-2018 <https://arcticdata.io/catalog/view/doi:10.18739/A21R6N14K>`_: ``<path_to_tide_models>/Arc5km2018/``
-    * `Arc2kmTM <https://arcticdata.io/catalog/view/doi:10.18739/A2PV6B79W>`_: ``<path_to_tide_models>/Arc2kmTM/``
+    * `Arc2kmTM <https://arcticdata.io/catalog/view/doi:10.18739/A2D21RK6K>`_: ``<path_to_tide_models>/Arc2kmTM/``
     * Gr1km-v2: ``<path_to_tide_models>/greenlandTMD_v2/``
 
 - TOPEX/POSEIDON global tide models [Egbert2002]_

--- a/pyTMD/tools.py
+++ b/pyTMD/tools.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 tools.py
-Written by Tyler Sutterley (11/2022)
+Written by Tyler Sutterley (01/2023)
 Jupyter notebook, user interface and plotting tools
 
 PYTHON DEPENDENCIES:
@@ -17,6 +17,7 @@ PYTHON DEPENDENCIES:
         https://github.com/matplotlib/matplotlib
 
 UPDATE HISTORY:
+    Updated 01/2023: use debug level logging instead of import warnings
     Updated 11/2022: place more imports within try/except statements
     Updated 08/2022: place some imports behind try/except statements
     Updated 05/2022: include world copy jump in webmercator maps
@@ -28,8 +29,8 @@ import io
 import os
 import copy
 import base64
+import logging
 import datetime
-import warnings
 import numpy as np
 import matplotlib
 matplotlib.rcParams['axes.linewidth'] = 2.0
@@ -45,25 +46,19 @@ import pyTMD.io.model
 try:
     import IPython
 except (ImportError, ModuleNotFoundError) as e:
-    warnings.filterwarnings("module")
-    warnings.warn("IPython not available", ImportWarning)
+    logging.debug("IPython not available")
 try:
     import ipyleaflet
 except (ImportError, ModuleNotFoundError) as e:
-    warnings.filterwarnings("module")
-    warnings.warn("ipyleaflet not available", ImportWarning)
+    logging.debug("ipyleaflet not available")
 try:
     import ipywidgets
 except (ImportError, ModuleNotFoundError) as e:
-    warnings.filterwarnings("module")
-    warnings.warn("ipywidgets not available", ImportWarning)
+    logging.debug("ipywidgets not available")
 try:
     import pyproj
 except (ImportError, ModuleNotFoundError) as e:
-    warnings.filterwarnings("module")
-    warnings.warn("pyproj not available", ImportWarning)
-# ignore warnings
-warnings.filterwarnings("ignore")
+    logging.debug("pyproj not available")
 
 class widgets:
     def __init__(self, **kwargs):

--- a/scripts/compute_LPET_elevations.py
+++ b/scripts/compute_LPET_elevations.py
@@ -64,6 +64,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 01/2023: added default field mapping for reading from netCDF4/HDF5
+        added data type keyword for netCDF4 output
     Updated 12/2022: single implicit import of pyTMD tools
     Updated 11/2022: place some imports within try/except statements
         use f-strings for formatting verbose or ascii output
@@ -271,7 +272,7 @@ def compute_LPET_elevations(input_file, output_file,
             delimiter=DELIMITER, header=False,
             columns=['time','lat','lon','tide_lpe'])
     elif (FORMAT == 'netCDF4'):
-        pyTMD.spatial.to_netCDF4(output, attrib, output_file)
+        pyTMD.spatial.to_netCDF4(output, attrib, output_file, data_type=TYPE)
     elif (FORMAT == 'HDF5'):
         pyTMD.spatial.to_HDF5(output, attrib, output_file)
     elif (FORMAT == 'geotiff'):

--- a/scripts/compute_LPT_displacements.py
+++ b/scripts/compute_LPT_displacements.py
@@ -68,6 +68,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 01/2023: added default field mapping for reading from netCDF4/HDF5
+        added data type keyword for netCDF4 output
     Updated 12/2022: single implicit import of pyTMD tools
         use constants class for ellipsoidal parameters
     Updated 11/2022: place some imports within try/except statements
@@ -345,7 +346,7 @@ def compute_LPT_displacements(input_file, output_file,
             delimiter=DELIMITER, header=False,
             columns=['time','lat','lon','tide_pole'])
     elif (FORMAT == 'netCDF4'):
-        pyTMD.spatial.to_netCDF4(output, attrib, output_file)
+        pyTMD.spatial.to_netCDF4(output, attrib, output_file, data_type=TYPE)
     elif (FORMAT == 'HDF5'):
         pyTMD.spatial.to_HDF5(output, attrib, output_file)
     elif (FORMAT == 'geotiff'):

--- a/scripts/compute_OPT_displacements.py
+++ b/scripts/compute_OPT_displacements.py
@@ -80,6 +80,7 @@ REFERENCES:
 
 UPDATE HISTORY:
     Updated 01/2023: added default field mapping for reading from netCDF4/HDF5
+        added data type keyword for netCDF4 output
     Updated 12/2022: single implicit import of pyTMD tools
         use constants class for ellipsoidal parameters
     Updated 11/2022: place some imports within try/except statements
@@ -378,7 +379,7 @@ def compute_OPT_displacements(input_file, output_file,
             delimiter=DELIMITER, header=False,
             columns=['time','lat','lon','tide_oc_pole'])
     elif (FORMAT == 'netCDF4'):
-        pyTMD.spatial.to_netCDF4(output, attrib, output_file)
+        pyTMD.spatial.to_netCDF4(output, attrib, output_file, data_type=TYPE)
     elif (FORMAT == 'HDF5'):
         pyTMD.spatial.to_HDF5(output, attrib, output_file)
     elif (FORMAT == 'geotiff'):

--- a/scripts/compute_tidal_currents.py
+++ b/scripts/compute_tidal_currents.py
@@ -92,6 +92,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 01/2023: added default field mapping for reading from netCDF4/HDF5
+        added data type keyword for netCDF4 output
     Updated 12/2022: single implicit import of pyTMD tools
     Updated 11/2022: place some imports within try/except statements
         use f-strings for formatting verbose or ascii output
@@ -392,7 +393,7 @@ def compute_tidal_currents(tide_dir, input_file, output_file,
             delimiter=DELIMITER, header=False,
             columns=['time','lat','lon','u','v'])
     elif (FORMAT == 'netCDF4'):
-        pyTMD.spatial.to_netCDF4(output, attrib, output_file)
+        pyTMD.spatial.to_netCDF4(output, attrib, output_file, data_type=TYPE)
     elif (FORMAT == 'HDF5'):
         pyTMD.spatial.to_HDF5(output, attrib, output_file)
     elif (FORMAT == 'geotiff'):
@@ -430,8 +431,7 @@ def arguments():
     # tide model to use
     choices = sorted(pyTMD.io.model.ocean_current())
     group.add_argument('--tide','-T',
-        metavar='TIDE', type=str,
-        choices=choices,
+        type=str, choices=choices,
         help='Tide model to use in calculating currents')
     parser.add_argument('--atlas-format',
         type=str, choices=('OTIS','netcdf'), default='netcdf',

--- a/scripts/compute_tidal_elevations.py
+++ b/scripts/compute_tidal_elevations.py
@@ -95,6 +95,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 01/2023: added default field mapping for reading from netCDF4/HDF5
+        added data type keyword for netCDF4 output
     Updated 12/2022: single implicit import of pyTMD tools
     Updated 11/2022: place some imports within try/except statements
         use f-strings for formatting verbose or ascii output
@@ -388,7 +389,7 @@ def compute_tidal_elevations(tide_dir, input_file, output_file,
             delimiter=DELIMITER, header=False,
             columns=['time','lat','lon',output_variable])
     elif (FORMAT == 'netCDF4'):
-        pyTMD.spatial.to_netCDF4(output, attrib, output_file)
+        pyTMD.spatial.to_netCDF4(output, attrib, output_file, data_type=TYPE)
     elif (FORMAT == 'HDF5'):
         pyTMD.spatial.to_HDF5(output, attrib, output_file)
     elif (FORMAT == 'geotiff'):
@@ -423,8 +424,7 @@ def arguments():
     choices = sorted(pyTMD.io.model.ocean_elevation() +
                      pyTMD.io.model.load_elevation())
     group.add_argument('--tide','-T',
-        metavar='TIDE', type=str,
-        choices=choices,
+        type=str, choices=choices,
         help='Tide model to use in correction')
     parser.add_argument('--atlas-format',
         type=str, choices=('OTIS','netcdf'), default='netcdf',


### PR DESCRIPTION
feat: use debug level logging instead of import warnings in `tools.py` to address #156
docs: don't have metavar for `--tide` to address #155
docs: updated v2 link for Arc2km to address #157
