### PR TITLE
fix: FES2022 extrapolated data have zeroed out inland water bodies for #309

### DIFF
--- a/pyTMD/io/FES.py
+++ b/pyTMD/io/FES.py
@@ -59,6 +59,7 @@ PROGRAM DEPENDENCIES:
 UPDATE HISTORY:
     Updated 07/2024: added new FES2022 to available known model versions
         FES2022 have masked longitudes, only extract longitude data
+        FES2022 extrapolated data have zeroed out inland water bodies
         added crop and bounds keywords for trimming model data
     Updated 01/2024: attempt to extract constituent IDs from filenames
     Updated 06/2023: extract ocean tide model variables for FES2012
@@ -725,6 +726,7 @@ def read_netcdf_file(
     # calculate complex form of constituent oscillation
     mask = (amp.data == amp.fill_value) | \
         (ph.data == ph.fill_value) | \
+        ((amp.data == 0) & (ph.data == 0)) | \
         np.isnan(amp.data) | np.isnan(ph.data)
     hc = np.ma.array(amp*np.exp(-1j*ph*np.pi/180.0), mask=mask,
         fill_value=np.ma.default_fill_value(np.dtype(complex)))

--- a/pyTMD/io/model.py
+++ b/pyTMD/io/model.py
@@ -1353,8 +1353,8 @@ class model:
         format: str
             format of the input definition file
 
-                - ``'ascii'`` for tab-delimited definition file
-                - ``'json'`` for JSON formatted definition file
+                - ``'ascii'``: tab-delimited definition file
+                - ``'json'``: JSON formatted definition file
         """
         # Opening definition file and assigning file ID number
         if isinstance(definition_file, io.IOBase):

--- a/scripts/compute_tidal_currents.py
+++ b/scripts/compute_tidal_currents.py
@@ -99,6 +99,7 @@ PROGRAM DEPENDENCIES:
 UPDATE HISTORY:
     Updated 07/2024: assert that data type is a known value
         added option to crop to the domain of the input data
+        added option to use JSON format definition files
     Updated 06/2024: include attributes in output parquet files
     Updated 05/2024: use function to reading parquet files to allow
         reading and parsing of geometry column from geopandas datasets
@@ -200,6 +201,7 @@ def compute_tidal_currents(tide_dir, input_file, output_file,
     ATLAS_FORMAT='netcdf',
     GZIP=True,
     DEFINITION_FILE=None,
+    DEFINITION_FORMAT='ascii',
     CROP=False,
     FORMAT='csv',
     VARIABLES=[],
@@ -219,7 +221,8 @@ def compute_tidal_currents(tide_dir, input_file, output_file,
 
     # get parameters for tide model
     if DEFINITION_FILE is not None:
-        model = pyTMD.io.model(tide_dir).from_file(DEFINITION_FILE)
+        model = pyTMD.io.model(tide_dir).from_file(DEFINITION_FILE,
+            format=DEFINITION_FORMAT)
     else:
         model = pyTMD.io.model(tide_dir, format=ATLAS_FORMAT,
             compressed=GZIP).current(TIDE_MODEL)
@@ -471,6 +474,9 @@ def arguments():
     group.add_argument('--definition-file',
         type=pathlib.Path,
         help='Tide model definition file')
+    parser.add_argument('--definition-format',
+        type=str, default='ascii', choices=('ascii', 'json'),
+        help='Format for model definition file')
     # crop tide model to (buffered) bounds of data
     parser.add_argument('--crop', '-C',
         default=False, action='store_true',
@@ -574,6 +580,7 @@ def main():
             ATLAS_FORMAT=args.atlas_format,
             GZIP=args.gzip,
             DEFINITION_FILE=args.definition_file,
+            DEFINITION_FORMAT=args.definition_format,
             CROP=args.crop,
             FORMAT=args.format,
             VARIABLES=args.variables,

--- a/scripts/compute_tidal_elevations.py
+++ b/scripts/compute_tidal_elevations.py
@@ -102,6 +102,7 @@ PROGRAM DEPENDENCIES:
 UPDATE HISTORY:
     Updated 07/2024: assert that data type is a known value
         added option to crop to the domain of the input data
+        added option to use JSON format definition files
     Updated 06/2024: include attributes in output parquet files
     Updated 05/2024: use function to reading parquet files to allow
         reading and parsing of geometry column from geopandas datasets
@@ -204,6 +205,7 @@ def compute_tidal_elevations(tide_dir, input_file, output_file,
     ATLAS_FORMAT='netcdf',
     GZIP=True,
     DEFINITION_FILE=None,
+    DEFINITION_FORMAT='ascii',
     CROP=False,
     FORMAT='csv',
     VARIABLES=[],
@@ -224,7 +226,8 @@ def compute_tidal_elevations(tide_dir, input_file, output_file,
 
     # get parameters for tide model
     if DEFINITION_FILE is not None:
-        model = pyTMD.io.model(tide_dir).from_file(DEFINITION_FILE)
+        model = pyTMD.io.model(tide_dir).from_file(DEFINITION_FILE,
+            format=DEFINITION_FORMAT)
     else:
         model = pyTMD.io.model(tide_dir, format=ATLAS_FORMAT,
             compressed=GZIP).elevation(TIDE_MODEL)
@@ -467,6 +470,9 @@ def arguments():
     group.add_argument('--definition-file',
         type=pathlib.Path,
         help='Tide model definition file')
+    parser.add_argument('--definition-format',
+        type=str, default='ascii', choices=('ascii', 'json'),
+        help='Format for model definition file')
     # crop tide model to (buffered) bounds of data
     parser.add_argument('--crop', '-C',
         default=False, action='store_true',
@@ -575,6 +581,7 @@ def main():
             ATLAS_FORMAT=args.atlas_format,
             GZIP=args.gzip,
             DEFINITION_FILE=args.definition_file,
+            DEFINITION_FORMAT=args.definition_format,
             CROP=args.crop,
             FORMAT=args.format,
             VARIABLES=args.variables,

--- a/test/model_FES2022b_extrapolated.def
+++ b/test/model_FES2022b_extrapolated.def
@@ -1,0 +1,9 @@
+format      FES
+name        FES2022
+model_file  fes2022b/ocean_tide_extrapolated/*fes2022.nc*
+type        z
+version     FES2022
+variable    tide_ocean
+scale     0.01
+compressed  True
+reference   https://doi.org/10.24400/527896/A01-2024.004

--- a/test/model_FES2022b_extrapolated.json
+++ b/test/model_FES2022b_extrapolated.json
@@ -1,0 +1,1 @@
+{"format": "FES", "name": "FES2022", "model_file": "fes2022b/ocean_tide_extrapolated/*fes2022.nc*", "type": "z", "version": "FES2022", "variable": "tide_ocean", "scale": 0.01, "compressed": true, "reference": "https://doi.org/10.24400/527896/A01-2024.004"}


### PR DESCRIPTION
feat: added option to use JSON format definition files
feat: add definition files for FES2022-extrapolated
