### PR TITLE
Fix Python 3.9 annotations error

### DIFF
--- a/pyTMD/math.py
+++ b/pyTMD/math.py
@@ -15,6 +15,8 @@ UPDATE HISTORY:
     Updated 12/2024: added function to calculate an aliasing frequency
     Written 11/2024
 """
+from __future__ import annotations
+
 import numpy as np
 from scipy.special import factorial
 


### PR DESCRIPTION
On PyTMD 2.19 our Python 3.9 tests have started failing:
https://github.com/GeoscienceAustralia/eo-tides/actions/runs/12424548030/job/34689878792#step:5:106
```
eo_tides/eo.py:18: in <module>
    from .model import model_tides
eo_tides/model.py:21: in <module>
    import pyTMD
.venv/lib/python3.9/site-packages/pyTMD/__init__.py:14: in <module>
    import pyTMD.arguments
.venv/lib/python3.9/site-packages/pyTMD/arguments.py:86: in <module>
    import pyTMD.astro
.venv/lib/python3.9/site-packages/pyTMD/astro.py:57: in <module>
    from pyTMD.math import (
.venv/lib/python3.9/site-packages/pyTMD/math.py:32: in <module>
    coefficients: list | np.ndarray,
E   TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

I think this is because "|" style typing in the `math` module isn't supported before Python 3.10 without importing `from __future__ import annotations` first.

This PR adds this line into `math.py`, to see if this resolves this error.
