### PR TITLE
chore: bump version to `3.0.5`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ keywords:
   - Solid Earth Tides
   - Tidal Prediction
 license: MIT
-version: "3.0.4"
-date-released: "2026-03-04"
+version: "3.0.5"
+date-released: "2026-03-24"
 message: If you use this software, please consider citing our article
   in the Journal of Open Source Software.
 

--- a/doc/source/release_notes/release-v3.0.5.rst
+++ b/doc/source/release_notes/release-v3.0.5.rst
@@ -1,0 +1,27 @@
+.. _release-v3.0.5:
+
+##################
+`Release v3.0.5`__
+##################
+
+* ``fix``: output data as a ``DataArray`` from ``extrapolate`` for `#537 <https://github.com/pyTMD/pyTMD/issues/537>`_ `(#538) <https://github.com/pyTMD/pyTMD/pull/538>`_
+* ``feat``: allow caching of the KD-tree during extrapolation `(#540) <https://github.com/pyTMD/pyTMD/pull/540>`_
+* ``refactor``: switch method for Legendre polynomials `(#541) <https://github.com/pyTMD/pyTMD/pull/541>`_
+* ``test``: compare ``Plm`` and ``dPlm`` against prior values `(#541) <https://github.com/pyTMD/pyTMD/pull/541>`_
+* ``fix``: handle the ``dPlm`` singularity at the poles `(#542) <https://github.com/pyTMD/pyTMD/pull/542>`_
+* ``docs``: add geocentric latitude section `(#543) <https://github.com/pyTMD/pyTMD/pull/543>`_
+* ``refactor``: clean up ``ephemerides`` method of calculating solid earth tides `(#543) <https://github.com/pyTMD/pyTMD/pull/543>`_
+* ``ci``: bump versions for ``nodejs`` deprecation `(#543) <https://github.com/pyTMD/pyTMD/pull/543>`_
+* ``ci``: smaller coverage reports `(#543) <https://github.com/pyTMD/pyTMD/pull/543>`_
+* ``feat``: add tide-generating forces from Tamura (1982) `(#544) <https://github.com/pyTMD/pyTMD/pull/544>`_
+* ``docs``: standardize how units are represented `(#544) <https://github.com/pyTMD/pyTMD/pull/544>`_
+* ``refactor``: add more constituents to length of day `(#544) <https://github.com/pyTMD/pyTMD/pull/544>`_
+* ``refactor``: make maximum degree (``lmax``) an argument `(#544) <https://github.com/pyTMD/pyTMD/pull/544>`_
+* ``test``: add comparison of Legendre polynomials vs HW95 `(#544) <https://github.com/pyTMD/pyTMD/pull/544>`_
+* ``docs``: standardize case of docstrings `(#545) <https://github.com/pyTMD/pyTMD/pull/545>`_
+* ``refactor``: clean up ephemerides corrections for SE tides `(#546) <https://github.com/pyTMD/pyTMD/pull/546>`_
+* ``refactor``: use Cartesian approach for TGF `(#547) <https://github.com/pyTMD/pyTMD/pull/547>`_
+* ``feat``: new options for lunisolar ECEF XYZ `(#547) <https://github.com/pyTMD/pyTMD/pull/547>`_
+* ``test``: add tests over all approximate lunisolar ECEF methods `(#547) <https://github.com/pyTMD/pyTMD/pull/547>`_
+
+.. __: https://github.com/pyTMD/pyTMD/releases/tag/3.0.5

--- a/pixi.lock
+++ b/pixi.lock
@@ -12563,8 +12563,8 @@ packages:
   timestamp: 1752805902938
 - pypi: ./
   name: pytmd
-  version: 3.0.4
-  sha256: 825722b31c3669c61564601035c623e32bb265c20b2bc29d071bc8efaae8570f
+  version: 3.0.5
+  sha256: 2a7cfd20efffafe559445d45d77c5893c94ca87a005dd4917b1abb0c0581b83b
   requires_dist:
   - h5netcdf
   - lxml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyTMD"
-version = "3.0.4"
+version = "3.0.5"
 description = "Python-based tidal prediction software for estimating ocean, load, solid Earth and pole tides"
 keywords = [
     "Ocean Tides",

--- a/test/test_solid_earth.py
+++ b/test/test_solid_earth.py
@@ -220,9 +220,9 @@ def test_solid_earth_tide():
     assert np.isclose(dy_expected, dxt['Y'])
     assert np.isclose(dz_expected, dxt['Z'])
 
-# parameterize ephemerides
-@pytest.mark.parametrize("EPHEMERIDES", ['approximate','JPL'])
-def test_solid_earth_radial(EPHEMERIDES):
+# parametrize over approximate methods
+@pytest.mark.parametrize("method", ['Kubo', 'Meeus', 'Montenbruck', 'JPL'])
+def test_solid_earth_radial(method):
     """Test radial solid tides with predictions from ICESat-2
     """
     times = np.array(['2018-10-14 00:21:48','2018-10-14 00:21:48',
@@ -249,10 +249,10 @@ def test_solid_earth_radial(EPHEMERIDES):
     # predict radial solid earth tides
     tide_free = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
         crs=4326, type='drift', standard='datetime', ellipsoid='WGS84',
-        ephemerides=EPHEMERIDES)
+        ephemerides=method)
     tide_mean = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
         crs=4326, type='drift', standard='datetime', ellipsoid='WGS84',
-        tide_system='mean_tide', ephemerides=EPHEMERIDES)
+        tide_system='mean_tide', ephemerides=method)
     # as using estimated ephemerides, assert within 1/2 mm
     assert np.allclose(tide_earth, tide_free, atol=5e-4)
     # sign differences with ATLAS product: correction is subtractive
@@ -262,9 +262,9 @@ def test_solid_earth_radial(EPHEMERIDES):
     assert np.allclose(tide_mean-tide_free, predicted, atol=5e-4)
 
 # parameterize method
-@pytest.mark.parametrize("CATALOG", ['CTE1973','T1987'])
-@pytest.mark.parametrize("METHOD", ['ASTRO5','IERS'])
-def test_body_tides(CATALOG, METHOD):
+@pytest.mark.parametrize("catalog", ['CTE1973','T1987'])
+@pytest.mark.parametrize("method", ['ASTRO5','IERS'])
+def test_body_tides(catalog, method):
     """Test simplified solid tides using predictions from ICESat-2
     """
     times = np.array(['2018-10-14 00:21:48','2018-10-14 00:21:48',
@@ -294,21 +294,21 @@ def test_body_tides(CATALOG, METHOD):
     # using tide potentials from Cartwright and Tayler (1971)
     ts = timescale.from_datetime(times)
     tide_free = pyTMD.predict.body_tide(ts.tide, ds,
-        deltat=ts.tt_ut1, tide_system='tide_free', method=METHOD,
-        catalog=CATALOG)
+        deltat=ts.tt_ut1, tide_system='tide_free', method=method,
+        catalog=catalog)
     tide_mean = pyTMD.predict.body_tide(ts.tide, ds,
-        deltat=ts.tt_ut1, tide_system='mean_tide', method=METHOD,
-        catalog=CATALOG)
+        deltat=ts.tt_ut1, tide_system='mean_tide', method=method,
+        catalog=catalog)
     # since we are using simplified body tides: assert within 2 mm
     assert np.allclose(tide_earth, tide_free['R'], atol=2e-3)
     assert np.allclose(tide_expected, tide_mean['R'], atol=2e-3)
     # predict radial solid earth tides
     tide_free = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
         crs=4326, type='drift', standard='datetime', tide_system='tide_free',
-        method='catalog', ephemerides=METHOD, catalog=CATALOG)
+        method='catalog', ephemerides=method, catalog=catalog)
     tide_mean = pyTMD.compute.SET_displacements(longitudes, latitudes, times,
         crs=4326, type='drift', standard='datetime', tide_system='mean_tide',
-        method='catalog', ephemerides=METHOD, catalog=CATALOG)
+        method='catalog', ephemerides=method, catalog=catalog)
     # since we are using simplified body tides: assert within 2 mm
     assert np.allclose(tide_earth, tide_free, atol=2e-3)
     assert np.allclose(tide_expected, tide_mean, atol=2e-3)


### PR DESCRIPTION
test: parametrize over approximate methods when testing solid earth tides
