### PR TITLE
refactor: parallel outputs from `earth_orientation` and `length_of_day`

### DIFF
--- a/doc/source/background/Time.rst
+++ b/doc/source/background/Time.rst
@@ -95,5 +95,5 @@ Many of the early estimates of the sub-daily variations in the length of day (LO
 
 .. plot:: ./background/length-of-day.py
     :show-source-link: False
-    :caption: Length of Day Variations from :cite:t:`Ray:1994dk`
+    :caption: Rotation Rate Variations due to a) Diurnal and Semi-Diurnal :cite:p:`Ray:1994dk` and b) Long-Period Tides :cite:p:`Ray:2014fu`. Red lines in b) denote values for the time period used for calculating the short-period tides in a). Variations in b) are dominated by the 18.6 year node tide cycle :cite:p:`Ray:2014fu`. 
     :align: center

--- a/doc/source/background/length-of-day.py
+++ b/doc/source/background/length-of-day.py
@@ -4,10 +4,10 @@ import timescale
 import matplotlib.pyplot as plt
 import matplotlib.offsetbox as offsetbox
 
-# MJD dates from Ray and Erofeeva (2014)
+# MJD dates from Ray and Erofeeva (2014) at daily resolution
 MJD1 = np.arange(37680, 55021)
-# dates from Ray (1994)
-MJD2 = 48830 + np.arange(86400 * 4) / 86400.0
+# MJD dates from Ray (1994) at minute resolution
+MJD2 = 48830 + np.arange(1440 * 4) / 1440.0
 
 # plot rotation rate variations
 fig, ax = plt.subplots(num=1, nrows=2, sharex=False, figsize=(8, 4))

--- a/doc/source/background/length-of-day.py
+++ b/doc/source/background/length-of-day.py
@@ -2,15 +2,47 @@ import pyTMD
 import numpy as np
 import timescale
 import matplotlib.pyplot as plt
+import matplotlib.offsetbox as offsetbox
 
+# MJD dates from Ray and Erofeeva (2014)
+MJD1 = np.arange(37680, 55021)
 # dates from Ray (1994)
-MJD = 48830 + np.arange(86400 * 4) / 86400.0
-ts = timescale.time.Timescale(MJD)
-ds = pyTMD.predict.earth_orientation(ts.tide)
-# plot length of day variations
-fig, ax = plt.subplots(num=1, figsize=(8, 4))
-ax.plot(MJD, 1e6 * ds.dUT, color="0.4")
-ax.set_xlabel("MJD")
-ax.set_ylabel("\u0394UT1 [\u03bcs]")
+MJD2 = 48830 + np.arange(86400 * 4) / 86400.0
+
+# plot rotation rate variations
+fig, ax = plt.subplots(num=1, nrows=2, sharex=False, figsize=(8, 4))
+
+# predict rotation rate variations for the time period of Ray (1994)
+ts = timescale.time.Timescale(MJD2)
+# short-period tides
+dsSP = pyTMD.predict.earth_orientation(ts.tide).sum(dim="constituent")
+ax[0].plot(MJD2, 1e3 * dsSP.dUT, color="0.4")
+
+# predict rotation rate variations for both time periods
+for MJD, color in zip([MJD1, MJD2], ["0.4", "red"]):
+    ts = timescale.time.Timescale(MJD)
+    # long-period tides
+    dsLP = pyTMD.predict.length_of_day(ts.tide).sum(dim="constituent")
+    ax[1].plot(MJD, 1e3 * dsLP.dUT, color=color)
+# add x and y labels
+ax[1].set_xlabel("MJD")
+ax[0].set_ylabel("\u0394UT [ms]")
+ax[1].set_ylabel("\u0394UT [ms]")
+ax[0].xaxis.get_major_locator().set_params(integer=True)
+ax[0].ticklabel_format(useOffset=False, style="plain")
+# add axes labels
+labels = ["a)", "b)"]
+for i, label in enumerate(labels):
+    ax[i].tick_params(which="both", direction="in")
+    at = offsetbox.AnchoredText(
+        label,
+        loc=2,
+        pad=0.0,
+        borderpad=0.5,
+        frameon=False,
+        prop=dict(size=12, weight="bold", color="k"),
+    )
+    ax[i].axes.add_artist(at)
+# set axis limits and show plot
 fig.tight_layout()
 plt.show()

--- a/pyTMD/predict/polar_motion.py
+++ b/pyTMD/predict/polar_motion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 polar_motion.py
-Written by Tyler Sutterley (03/2026)
+Written by Tyler Sutterley (04/2026)
 Prediction routines for pole tides and Earth Orientation Parameters (EOPs)
 
 PYTHON DEPENDENCIES:
@@ -19,6 +19,7 @@ PROGRAM DEPENDENCIES:
     math.py: Special functions of mathematical physics
 
 UPDATE HISTORY:
+    Updated 04/2026: parallel outputs from earth_orientation and length_of_day
     Written 03/2026: split up prediction functions into separate files
 """
 
@@ -316,13 +317,14 @@ def earth_orientation(
     gamma = gha + circle / 2.0
     # variable for multiples of 90 degrees (Ray technical note 2017)
     K = circle / 4.0 + np.zeros_like((MJD))
-    # data array of arguments
+    # delaunay arguments
+    args = ["l", "lp", "F", "D", "omega", "gamma", "k"]
     arguments = xr.DataArray(
         np.c_[l, lp, F, D, omega, gamma, K],
         dims=["time", "argument"],
         coords=dict(
             time=np.atleast_1d(MJD),
-            argument=["l", "lp", "F", "D", "omega", "gamma", "k"],
+            argument=args,
         ),
     )
     # major constituents in Ray (1994) and latest IERS conventions
@@ -395,7 +397,7 @@ def earth_orientation(
         delaunay_table,
         dims=["argument", "constituent"],
         coords=dict(
-            argument=["l", "lp", "F", "D", "omega", "gamma", "k"],
+            argument=args,
             constituent=constituents,
         ),
     )
@@ -445,20 +447,26 @@ def earth_orientation(
     # convert from arcseconds to complex phase in radians
     phase = np.exp(1j * pyTMD.math.asec2rad(G))
     # calculate EOP corrections
-    corrections = (dEOP.real * phase.real + dEOP.imag * phase.imag).sum(
-        dim="constituent"
-    )
+    corrections = dEOP.real * phase.real + dEOP.imag * phase.imag
+    # calculate angular frequency of constituents
+    omega = pyTMD.constituents.frequency(constituents)
     # create output dataset from data arrays
     ds = xr.Dataset()
+    # polar motion corrections in X and Y (arcseconds)
     ds["dX"] = 1e-3 * corrections.sel(EOP="dX")
     ds["dX"].attrs["units"] = "arcseconds"
     ds["dX"].attrs["long_name"] = "anomaly in polar motion in X"
     ds["dY"] = 1e-3 * corrections.sel(EOP="dY")
     ds["dY"].attrs["units"] = "arcseconds"
     ds["dY"].attrs["long_name"] = "anomaly in polar motion in Y"
+    # delta UT1-TAI (seconds)
     ds["dUT"] = 1e-4 * corrections.sel(EOP="dUT")
     ds["dUT"].attrs["units"] = "seconds"
     ds["dUT"].attrs["long_name"] = "anomaly in UT1-TAI"
+    # period of constituent (days)
+    period = 2.0 * np.pi / (86400.0 * omega)
+    ds["period"] = ("constituent", period)
+    ds["period"].attrs["units"] = "days"
     # return the variations in earth rotation
     return ds
 
@@ -498,20 +506,19 @@ def length_of_day(
     tau = 15.0 * hour - s + h
     # variable for multiples of 90 degrees (Ray technical note 2017)
     k = 90.0 + 0.0 * MJD
-    # dataset of arguments
+    # astronomical arguments
     # note the sign change to go from N to N'
-    arguments = xr.Dataset(
-        data_vars=dict(
-            tau=(["time"], tau),
-            s=(["time"], s),
-            h=(["time"], h),
-            p=(["time"], p),
-            n=(["time"], -n),
-            pp=(["time"], pp),
-            k=(["time"], k),
+    args = ["tau", "s", "h", "p", "n", "pp", "k"]
+    arguments = np.c_[tau, s, h, p, -n, pp, k]
+    # convert to dataarray
+    arguments = xr.DataArray(
+        arguments,
+        dims=["time", "argument"],
+        coords=dict(
+            time=np.atleast_1d(MJD),
+            argument=args,
         ),
-        coords=dict(time=np.atleast_1d(MJD)),
-    ).to_dataarray(dim="argument")
+    )
     # parse rotation rate table from Ray and Erofeeva (2014)
     ZROT = pyTMD.constituents._parse_rotation_rate_table()
     # Doodson coefficients
@@ -528,19 +535,20 @@ def length_of_day(
             ]
         ),
         dims=["argument", "constituent"],
-        coords=dict(argument=["tau", "s", "h", "p", "n", "pp", "k"]),
+        coords=dict(argument=args),
     )
     # equilibrium phase converted to radians
     G = np.radians(arguments.dot(coefficients))
+    # calculate length of day corrections
+    dUT = ZROT["UTc"] * np.cos(G) + ZROT["UTs"] * np.sin(G)
+    dLOD = ZROT["dLODc"] * np.cos(G) + ZROT["dLODs"] * np.sin(G)
     # create output dataset
     ds = xr.Dataset(coords=dict(time=np.atleast_1d(MJD)))
-    # compute delta UT1-TAI (seconds)
-    dUT = ZROT["UTc"] * np.cos(G) + ZROT["UTs"] * np.sin(G)
+    # delta UT1-TAI (seconds)
     ds["dUT"] = 1e-6 * dUT
     ds["dUT"].attrs["units"] = "seconds"
     ds["dUT"].attrs["long_name"] = "anomaly in UT1-TAI"
-    # compute delta LOD (seconds per day)
-    dLOD = ZROT["dLODc"] * np.cos(G) + ZROT["dLODs"] * np.sin(G)
+    # delta LOD (seconds per day)
     ds["dLOD"] = 1e-6 * dLOD
     ds["dLOD"].attrs["units"] = "seconds per day"
     ds["dLOD"].attrs["long_name"] = "excess length of day"

--- a/pyTMD/predict/polar_motion.py
+++ b/pyTMD/predict/polar_motion.py
@@ -392,7 +392,7 @@ def earth_orientation(
     delaunay_table[:, 27] = [0, 0, -2, 2, -2, 2, 0]  # s2
     delaunay_table[:, 28] = [0, 1, -2, 2, -2, 2, 2]  # r2
     delaunay_table[:, 29] = [0, 0, 0, 0, 0, 2, 0]  # k2
-    # convert to data array of coefficients
+    # convert delaunay coefficients to DataArray
     delaunay_table = xr.DataArray(
         delaunay_table,
         dims=["argument", "constituent"],
@@ -433,7 +433,7 @@ def earth_orientation(
     dEOP[:, 27] = [0.0636 - 0.1441j, 0.0866 + 0.0592j, -0.0016 - 0.0755j]
     dEOP[:, 28] = [0.0006 - 0.0012j, 0.0007 + 0.0005j, -0.0000 - 0.0006j]
     dEOP[:, 29] = [0.0191 - 0.0385j, 0.0231 + 0.0177j, -0.0004 - 0.0210j]
-    # convert to data array of EOP corrections
+    # convert EOP corrections to DataArray
     dEOP = xr.DataArray(
         dEOP,
         dims=["EOP", "constituent"],
@@ -449,8 +449,8 @@ def earth_orientation(
     # calculate EOP corrections
     corrections = dEOP.real * phase.real + dEOP.imag * phase.imag
     # calculate angular frequency of constituents
-    omega = pyTMD.constituents.frequency(constituents)
-    # create output dataset from data arrays
+    omegas = pyTMD.constituents.frequency(constituents)
+    # create output Dataset from DataArray objects
     ds = xr.Dataset()
     # polar motion corrections in X and Y (arcseconds)
     ds["dX"] = 1e-3 * corrections.sel(EOP="dX")
@@ -464,8 +464,8 @@ def earth_orientation(
     ds["dUT"].attrs["units"] = "seconds"
     ds["dUT"].attrs["long_name"] = "anomaly in UT1-TAI"
     # period of constituent (days)
-    period = 2.0 * np.pi / (86400.0 * omega)
-    ds["period"] = ("constituent", period)
+    periods = 2.0 * np.pi / (86400.0 * omegas)
+    ds["period"] = ("constituent", periods)
     ds["period"].attrs["units"] = "days"
     # return the variations in earth rotation
     return ds
@@ -510,7 +510,7 @@ def length_of_day(
     # note the sign change to go from N to N'
     args = ["tau", "s", "h", "p", "n", "pp", "k"]
     arguments = np.c_[tau, s, h, p, -n, pp, k]
-    # convert to dataarray
+    # convert arguments to DataArray
     arguments = xr.DataArray(
         arguments,
         dims=["time", "argument"],
@@ -542,7 +542,7 @@ def length_of_day(
     # calculate length of day corrections
     dUT = ZROT["UTc"] * np.cos(G) + ZROT["UTs"] * np.sin(G)
     dLOD = ZROT["dLODc"] * np.cos(G) + ZROT["dLODs"] * np.sin(G)
-    # create output dataset
+    # create output Dataset from DataArray objects
     ds = xr.Dataset(coords=dict(time=np.atleast_1d(MJD)))
     # delta UT1-TAI (seconds)
     ds["dUT"] = 1e-6 * dUT

--- a/pyTMD/predict/solid_earth.py
+++ b/pyTMD/predict/solid_earth.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 solid_earth.py
-Written by Tyler Sutterley (03/2026)
+Written by Tyler Sutterley (04/2026)
 Prediction routines for solid Earth (body) tides
 
 PYTHON DEPENDENCIES:
@@ -20,6 +20,7 @@ PROGRAM DEPENDENCIES:
     spatial.py: utilities for working with geospatial data
 
 UPDATE HISTORY:
+    Updated 04/2026: use xarray dot product for calculating constituent phases
     Updated 03/2026: use table of body tide love numbers for degrees 4+
     Written 03/2026: split up prediction functions into separate files
 """
@@ -165,17 +166,32 @@ def body_tide(
     k = 90.0 + np.zeros_like(MJD)
 
     # astronomical and planetary mean longitudes
+    args = ["tau", "s", "h", "p", "n", "pp", "k"]
     if kwargs["include_planets"]:
         # calculate planetary mean longitudes
         # me: Mercury, ve: Venus, ma: Mars, ju: Jupiter, sa: Saturn
-        me, ve, ma, ju, sa = pyTMD.astro.planetary_longitudes(MJD)
-        fargs = np.c_[tau, s, h, p, n, pp, k, me, ve, ma, ju, sa]
-        nargs = 12
+        me, ve, ma, ju, sa = pyTMD.astro.planetary_longitudes(MJD + deltat)
+        arguments = np.c_[tau, s, h, p, n, pp, k, me, ve, ma, ju, sa]
+        args.extend(["me", "ve", "ma", "ju", "sa"])
     else:
-        fargs = np.c_[tau, s, h, p, n, pp, k]
-        nargs = 7
+        arguments = np.c_[tau, s, h, p, n, pp, k]
+    # convert to dataarray
+    arguments = xr.DataArray(
+        arguments,
+        dims=["time", "argument"],
+        coords=dict(
+            time=np.atleast_1d(MJD),
+            argument=args,
+        ),
+    )
+    # number of arguments
+    nargs = len(args)
     # allocate array for Doodson coefficients
-    coef = np.zeros((nargs))
+    coef = xr.DataArray(
+        np.zeros((nargs)),
+        dims="argument",
+        coords=dict(argument=args),
+    )
 
     # longitudes and colatitudes in radians
     phi = np.radians(ds.x)
@@ -266,7 +282,7 @@ def body_tide(
         if (omega == 0) and (tide_system.lower() == "mean_tide"):
             continue
         # determine constituent phase using equilibrium arguments
-        G = pyTMD.math.normalize_angle(np.dot(fargs, coef))
+        G = pyTMD.math.normalize_angle(arguments.dot(coef))
         # convert phase angles to radians
         phase[:] = np.radians(G)
         # rotate spherical harmonic functions by phase angles

--- a/pyTMD/predict/solid_earth.py
+++ b/pyTMD/predict/solid_earth.py
@@ -153,54 +153,6 @@ def body_tide(
     # convert dates to Modified Julian Days
     MJD = t + _mjd_tide
 
-    # compute principal mean longitudes
-    # convert dates into Ephemeris Time
-    s, h, p, n, pp = pyTMD.astro.mean_longitudes(MJD + deltat, method=method)
-    # initial time conversions
-    hour = 24.0 * np.mod(MJD, 1)
-    # convert from hours solar time into mean lunar time in degrees
-    tau = 15.0 * hour - s + h
-    # variable for multiples of 90 degrees (Ray technical note 2017)
-    # full expansion of Equilibrium Tide includes some negative cosine
-    # terms and some sine terms (Pugh and Woodworth, 2014)
-    k = 90.0 + np.zeros_like(MJD)
-
-    # astronomical and planetary mean longitudes
-    args = ["tau", "s", "h", "p", "n", "pp", "k"]
-    if kwargs["include_planets"]:
-        # calculate planetary mean longitudes
-        # me: Mercury, ve: Venus, ma: Mars, ju: Jupiter, sa: Saturn
-        me, ve, ma, ju, sa = pyTMD.astro.planetary_longitudes(MJD + deltat)
-        arguments = np.c_[tau, s, h, p, n, pp, k, me, ve, ma, ju, sa]
-        args.extend(["me", "ve", "ma", "ju", "sa"])
-    else:
-        arguments = np.c_[tau, s, h, p, n, pp, k]
-    # convert to dataarray
-    arguments = xr.DataArray(
-        arguments,
-        dims=["time", "argument"],
-        coords=dict(
-            time=np.atleast_1d(MJD),
-            argument=args,
-        ),
-    )
-    # number of arguments
-    nargs = len(args)
-    # allocate array for Doodson coefficients
-    coef = xr.DataArray(
-        np.zeros((nargs)),
-        dims="argument",
-        coords=dict(argument=args),
-    )
-
-    # longitudes and colatitudes in radians
-    phi = np.radians(ds.x)
-    th = np.radians(90.0 - ds.y)
-
-    # allocate for output body tide estimates (meters)
-    # latitudinal, longitudinal and radial components
-    zeta = xr.Dataset()
-
     # check if tide catalog includes planetary contributions
     if catalog == "HW1995":
         # catalog includes planetary contributions
@@ -228,6 +180,51 @@ def body_tide(
         include_planets=include_planets,
     )
 
+    # compute principal mean longitudes
+    # convert dates into Ephemeris Time
+    s, h, p, n, pp = pyTMD.astro.mean_longitudes(MJD + deltat, method=method)
+    # initial time conversions
+    hour = 24.0 * np.mod(MJD, 1)
+    # convert from hours solar time into mean lunar time in degrees
+    tau = 15.0 * hour - s + h
+    # variable for multiples of 90 degrees (Ray technical note 2017)
+    # full expansion of Equilibrium Tide includes some negative cosine
+    # terms and some sine terms (Pugh and Woodworth, 2014)
+    k = 90.0 + np.zeros_like(MJD)
+
+    # astronomical and planetary mean longitudes
+    args = ["tau", "s", "h", "p", "n", "pp", "k"]
+    # verify that the catalog includes planetary contributions
+    if kwargs["include_planets"] and include_planets:
+        # calculate planetary mean longitudes
+        # me: Mercury, ve: Venus, ma: Mars, ju: Jupiter, sa: Saturn
+        me, ve, ma, ju, sa = pyTMD.astro.planetary_longitudes(MJD + deltat)
+        arguments = np.c_[tau, s, h, p, n, pp, k, me, ve, ma, ju, sa]
+        args.extend(["me", "ve", "ma", "ju", "sa"])
+    else:
+        arguments = np.c_[tau, s, h, p, n, pp, k]
+    # convert arguments to DataArray
+    arguments = xr.DataArray(
+        arguments,
+        dims=["time", "argument"],
+        coords=dict(
+            time=np.atleast_1d(MJD),
+            argument=args,
+        ),
+    )
+    # number of arguments
+    nargs = len(args)
+    # allocate array for Doodson coefficients
+    coef = xr.DataArray(
+        np.zeros((nargs)),
+        dims="argument",
+        coords=dict(argument=args),
+    )
+
+    # longitudes and colatitudes in radians
+    phi = np.radians(ds.x)
+    th = np.radians(90.0 - ds.y)
+
     # precompute spherical harmonic functions and derivatives
     # will need to be rotated by constituent phase
     Ylm = xr.Dataset()
@@ -243,6 +240,10 @@ def body_tide(
         dims="time",
         coords=dict(time=np.atleast_1d(MJD)),
     )
+
+    # allocate for output body tide estimates (meters)
+    # latitudinal, longitudinal and radial components
+    zeta = xr.Dataset()
     # initialize output body tides
     for key in ["R", "N", "E"]:
         zeta[key] = xr.zeros_like(th * phase)


### PR DESCRIPTION
refactor: use `xarray` dot product for calculating constituent phases
docs: include long-period length of day in time background